### PR TITLE
chore: Fixed warnings on Elixir 1.17 due to calling function without parentheses.

### DIFF
--- a/lib/nebulex/adapters/nebulex_adapters_horde.ex
+++ b/lib/nebulex/adapters/nebulex_adapters_horde.ex
@@ -132,7 +132,7 @@ defmodule Nebulex.Adapters.Horde do
         name: normalize_module_name([name, Supervisor]),
         strategy: :rest_for_one,
         children: [
-          {cache.__primary__, primary_opts},
+          {cache.__primary__(), primary_opts},
           Nebulex.Adapters.Horde.Registry.child_spec(registry_name, horde_registry_opts),
           {Nebulex.Adapters.Horde.DynamicSupervisor, horde_dynamic_supervisor_opts}
         ]
@@ -311,12 +311,12 @@ defmodule Nebulex.Adapters.Horde do
 
   @doc false
   def with_dynamic_cache(%{cache: cache, primary_name: nil}, action, args) do
-    apply(cache.__primary__, action, args)
+    apply(cache.__primary__(), action, args)
   end
 
   def with_dynamic_cache(%{cache: cache, primary_name: primary_name}, action, args) do
-    cache.__primary__.with_dynamic_cache(primary_name, fn ->
-      apply(cache.__primary__, action, args)
+    cache.__primary__().with_dynamic_cache(primary_name, fn ->
+      apply(cache.__primary__(), action, args)
     end)
   end
 


### PR DESCRIPTION
Recently I upgraded one of the projects I am working on from Elixir 1.15 to Elixir 1.17.3 and we started getting the following warnings:

```
warning: using map.field notation (without parentheses) to invoke function MyProject.Cache.Nebulex.__primary__() is deprecated, you must add parentheses instead: remote.function()
  (nebulex_adapters_horde 1.0.1) lib/nebulex/adapters/nebulex_adapters_horde.ex:135: Nebulex.Adapters.Horde.init/1
  (nebulex 2.6.3) lib/nebulex/cache/supervisor.ex:69: Nebulex.Cache.Supervisor.init/1
  (stdlib 6.1.1) supervisor.erl:869: :supervisor.init/1
  (stdlib 6.1.1) gen_server.erl:2229: :gen_server.init_it/2
  (stdlib 6.1.1) gen_server.erl:2184: :gen_server.init_it/6
```

For some reason these warnings are being logged with `error` log level and tripping some alerts setup around the Nebulex cache.

This pull request adds the missing parentheses and it should fix the warnings.